### PR TITLE
fix: fix examples and use strings.Builder instead of bytes.Buffer

### DIFF
--- a/examples/alternate.go
+++ b/examples/alternate.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	f, err := fsm.New(
 		"idle",
-		fsm.Transistions[string, string]{
+		fsm.Transitions[string, string]{
 			{Event: "scan", Src: []string{"idle"}, Dst: "scanning"},
 			{Event: "working", Src: []string{"scanning"}, Dst: "scanning"},
 			{Event: "situation", Src: []string{"scanning"}, Dst: "scanning"},

--- a/examples/data.go
+++ b/examples/data.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	fsm, err := fsm.New(
 		"idle",
-		fsm.Transistions[string, string]{
+		fsm.Transitions[string, string]{
 			{Event: "produce", Src: []string{"idle"}, Dst: "idle"},
 			{Event: "consume", Src: []string{"idle"}, Dst: "idle"},
 		},

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -12,7 +12,7 @@ import (
 func main() {
 	fsm, err := fsm.New(
 		"closed",
-		fsm.Transistions[string, string]{
+		fsm.Transitions[string, string]{
 			{Event: "open", Src: []string{"closed"}, Dst: "open"},
 			{Event: "close", Src: []string{"open"}, Dst: "closed"},
 		},

--- a/examples/struct.go
+++ b/examples/struct.go
@@ -22,7 +22,7 @@ func NewDoor(to string) *Door {
 	var err error
 	d.FSM, err = fsm.New(
 		"closed",
-		fsm.Transistions[string, string]{
+		fsm.Transitions[string, string]{
 			{Event: "open", Src: []string{"closed"}, Dst: "open"},
 			{Event: "close", Src: []string{"open"}, Dst: "closed"},
 		},

--- a/graphviz_visualizer.go
+++ b/graphviz_visualizer.go
@@ -3,13 +3,14 @@ package fsm
 import (
 	"bytes"
 	"fmt"
+	"strings"
 
 	"golang.org/x/exp/constraints"
 )
 
 // Visualize outputs a visualization of a FSM in Graphviz format.
 func Visualize[E constraints.Ordered, S constraints.Ordered](fsm *FSM[E, S]) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 
 	// we sort the key alphabetically to have a reproducible graph output
 	sortedEKeys := getSortedTransitionKeys(fsm.transitions)
@@ -23,38 +24,38 @@ func Visualize[E constraints.Ordered, S constraints.Ordered](fsm *FSM[E, S]) str
 	return buf.String()
 }
 
-func writeHeaderLine(buf *bytes.Buffer) {
+func writeHeaderLine(buf *strings.Builder) {
 	buf.WriteString(`digraph fsm {`)
 	buf.WriteString("\n")
 }
 
-func writeTransitions[E constraints.Ordered, S constraints.Ordered](buf *bytes.Buffer, current S, sortedEKeys []eKey[E, S], transitions map[eKey[E, S]]S) {
+func writeTransitions[E constraints.Ordered, S constraints.Ordered](buf *strings.Builder, current S, sortedEKeys []eKey[E, S], transitions map[eKey[E, S]]S) {
+	var b bytes.Buffer
+
 	// make sure the current state is at top
 	for _, k := range sortedEKeys {
+		v := transitions[k]
+		line := fmt.Sprintf(`    "%v" -> "%v" [ label = "%v" ];`, k.src, v, k.event)
 		if k.src == current {
-			v := transitions[k]
-			buf.WriteString(fmt.Sprintf(`    "%v" -> "%v" [ label = "%v" ];`, k.src, v, k.event))
-			buf.WriteString("\n")
+			buf.WriteString(line)
+		} else {
+			b.WriteString(line)
 		}
+		buf.WriteString("\n")
 	}
-	for _, k := range sortedEKeys {
-		if k.src != current {
-			v := transitions[k]
-			buf.WriteString(fmt.Sprintf(`    "%v" -> "%v" [ label = "%v" ];`, k.src, v, k.event))
-			buf.WriteString("\n")
-		}
+	if b.Len() > 0 {
+		buf.Write(b.Bytes())
 	}
-
 	buf.WriteString("\n")
 }
 
-func writeStates[S constraints.Ordered](buf *bytes.Buffer, sortedStateKeys []S) {
+func writeStates[S constraints.Ordered](buf *strings.Builder, sortedStateKeys []S) {
 	for _, k := range sortedStateKeys {
 		buf.WriteString(fmt.Sprintf(`    "%v";`, k))
 		buf.WriteString("\n")
 	}
 }
 
-func writeFooter(buf *bytes.Buffer) {
+func writeFooter(buf *strings.Builder) {
 	buf.WriteString(fmt.Sprintln("}"))
 }

--- a/mermaid_visualizer.go
+++ b/mermaid_visualizer.go
@@ -1,8 +1,8 @@
 package fsm
 
 import (
-	"bytes"
 	"fmt"
+	"strings"
 
 	"golang.org/x/exp/constraints"
 )
@@ -32,7 +32,7 @@ func VisualizeForMermaidWithGraphType[E constraints.Ordered, S constraints.Order
 }
 
 func visualizeForMermaidAsStateDiagram[E constraints.Ordered, S constraints.Ordered](fsm *FSM[E, S]) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 
 	sortedTransitionKeys := getSortedTransitionKeys(fsm.transitions)
 
@@ -50,7 +50,7 @@ func visualizeForMermaidAsStateDiagram[E constraints.Ordered, S constraints.Orde
 
 // visualizeForMermaidAsFlowChart outputs a visualization of a FSM in Mermaid format (including highlighting of current state).
 func visualizeForMermaidAsFlowChart[E constraints.Ordered, S constraints.Ordered](fsm *FSM[E, S]) string {
-	var buf bytes.Buffer
+	var buf strings.Builder
 
 	sortedTransitionKeys := getSortedTransitionKeys(fsm.transitions)
 	sortedStates, statesToIDMap := getSortedStates(fsm.transitions)
@@ -63,11 +63,11 @@ func visualizeForMermaidAsFlowChart[E constraints.Ordered, S constraints.Ordered
 	return buf.String()
 }
 
-func writeFlowChartGraphType(buf *bytes.Buffer) {
+func writeFlowChartGraphType(buf *strings.Builder) {
 	buf.WriteString("graph LR\n")
 }
 
-func writeFlowChartStates[S constraints.Ordered](buf *bytes.Buffer, sortedStates []S, statesToIDMap map[S]string) {
+func writeFlowChartStates[S constraints.Ordered](buf *strings.Builder, sortedStates []S, statesToIDMap map[S]string) {
 	for _, state := range sortedStates {
 		buf.WriteString(fmt.Sprintf(`    %s[%v]`, statesToIDMap[state], state))
 		buf.WriteString("\n")
@@ -76,7 +76,7 @@ func writeFlowChartStates[S constraints.Ordered](buf *bytes.Buffer, sortedStates
 	buf.WriteString("\n")
 }
 
-func writeFlowChartTransitions[E constraints.Ordered, S constraints.Ordered](buf *bytes.Buffer, transitions map[eKey[E, S]]S, sortedTransitionKeys []eKey[E, S], statesToIDMap map[S]string) {
+func writeFlowChartTransitions[E constraints.Ordered, S constraints.Ordered](buf *strings.Builder, transitions map[eKey[E, S]]S, sortedTransitionKeys []eKey[E, S], statesToIDMap map[S]string) {
 	for _, transition := range sortedTransitionKeys {
 		target := transitions[transition]
 		buf.WriteString(fmt.Sprintf(`    %s --> |%v| %s`, statesToIDMap[transition.src], transition.event, statesToIDMap[target]))
@@ -85,7 +85,7 @@ func writeFlowChartTransitions[E constraints.Ordered, S constraints.Ordered](buf
 	buf.WriteString("\n")
 }
 
-func writeFlowChartHighlightCurrent[S constraints.Ordered](buf *bytes.Buffer, current S, statesToIDMap map[S]string) {
+func writeFlowChartHighlightCurrent[S constraints.Ordered](buf *strings.Builder, current S, statesToIDMap map[S]string) {
 	buf.WriteString(fmt.Sprintf(`    style %s fill:%s`, statesToIDMap[current], highlightingColor))
 	buf.WriteString("\n")
 }


### PR DESCRIPTION
 fix examples and README, use strings.Builder instead of bytes.Buffer.